### PR TITLE
Build: TESTONE DO NOT MERGE 

### DIFF
--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -10,7 +10,7 @@ import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
 
 const templateNamePrefix = 'associated_template_test';
 const templateName = `${templateNamePrefix}-${randomName()}`;
-const regClient = new RHSMClient('AssociatedTemplateCRUDTest');
+const regClient = new RHSMClient(`AssociatedTemplateCRUDTest-${randomName()}`);
 
 test.describe('Associated Template CRUD', async () => {
   test('Warn against template deletion when associated to a system and not warn after unregistration', async ({

--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -5,7 +5,7 @@ import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
 
 const templateNamePrefix = 'integration_test_template';
 const templateName = `${templateNamePrefix}-${randomName()}`;
-const regClient = new RHSMClient('RHSMClientTest');
+const regClient = new RHSMClient(`RHSMClientTest-${randomName()}`);
 let firstVersion;
 
 test.describe('Test System With Template', async () => {


### PR DESCRIPTION
    to prevent name collision in test runs
    containers used as clients must have unique names

## Summary

## Testing steps
